### PR TITLE
Use HTTP2 rather than dated HTTP APNs

### DIFF
--- a/.profile.d/certificates.sh
+++ b/.profile.d/certificates.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
 mkdir -p certificates
+
 echo "$APNS_PRIVATE_KEY" > certificates/private.pem
 echo "$APNS_PUBLIC_KEY" > certificates/public.pem
 
+echo "$APNS_PRIVATE_KEY" > certificates/production.pem
+echo "$APNS_PUBLIC_KEY" >> certificates/production.pem

--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-apns = "==2.0.1"
+apns2 = {git = "https://github.com/Pr0Ger/PyAPNs2.git",ref = "6f3b2a7456ef22c6aafc1467618f665130b0aeea"}
 bugsnag = "*"
 click = "==3.3"
 gunicorn = "==19.9.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e4f1e05cf4ad5255b7109f0930dffea2dc6aa1a37d7dfc4e717dc5662b18b480"
+            "sha256": "fc7cf4216bfb379546e2b24caefae698a102e405d861d25d3aa51f07ddfee2e9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,12 +16,9 @@
         ]
     },
     "default": {
-        "apns": {
-            "hashes": [
-                "sha256:c81c76d36a6a7b9d40c78e1f08bd0f69cabb48a15a9b4483625e769082d3c5c9"
-            ],
-            "index": "pypi",
-            "version": "==2.0.1"
+        "apns2": {
+            "git": "https://github.com/Pr0Ger/PyAPNs2.git",
+            "ref": "6f3b2a7456ef22c6aafc1467618f665130b0aeea"
         },
         "bugsnag": {
             "hashes": [


### PR DESCRIPTION
This PR switches out the `apns` with the `apns2` library. In oder to get it working with our keys I added my own `Credentials` implementation: the library only supports textual password, not keys.

Please note that along with switching out the library, the APNs client has been made global. This means the connection is only made once, and kept alive with a heartbeat. Relevant apple documentation quote:

> "Keep your connections with APNs open across multiple notifications; do not repeatedly open and close connections. APNs treats rapid connection and disconnection as a denial-of-service attack." 
[[Source]](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html)

Another important change is that `send_notification` does not have a return value, but throws exceptions in case APNs stuff goes wrong. As far as I understand, the return value was never really used, and caused failed jobs to still appear as succeeded in the Redis queue. Throwing exceptions will definitely mark a job as failed, giving us a better overview of what is going wrong in the future.
