### PR TITLE
Prevent connecting to database twice

### DIFF
--- a/palaverapi/views.py
+++ b/palaverapi/views.py
@@ -182,22 +182,21 @@ class PushView(PermissionRequiredMixin, RESTView):
         intent = attributes.get('intent', None)
         private = attributes.get('private', False)
 
-        with database:
-            token = self.get_token()
-            if not token:
-                return ProblemResponse(401, 'Unauthorized')
+        token = self.get_token()
+        if not token:
+            return ProblemResponse(401, 'Unauthorized')
 
-            queue.enqueue(
-                send_notification,
-                token.device.apns_token,
-                message,
-                sender,
-                channel,
-                badge,
-                network,
-                intent,
-                private,
-            )
+        queue.enqueue(
+            send_notification,
+            token.device.apns_token,
+            message,
+            sender,
+            channel,
+            badge,
+            network,
+            intent,
+            private,
+        )
 
         return Response(status=202)
 


### PR DESCRIPTION
On peewee 3 (#26) tests crash with `OperationalError: Connection already opened`. 

The issue here is that when `PermissionRequiredMixin.dispatch()` is called, `get_token()` uses the database without being in a `with` block. By moving the `with` block into the `get_token()` method, the double connection is avoided. 