### PR TITLE
Use problem+json for all errors

### DIFF
--- a/palaverapi/tests/test_http.py
+++ b/palaverapi/tests/test_http.py
@@ -1,0 +1,23 @@
+import unittest
+import json
+
+from rivr.tests import TestClient
+
+from palaverapi.views import app
+
+
+class HTTPTests(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+
+    def test_404(self):
+        response = self.client.get('/404')
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.headers['Content-Type'], 'application/problem+json')
+        self.assertEqual(response.content, '{"title": "Resource Not Found"}')
+
+    def test_500(self):
+        response = self.client.get('/500')
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.headers['Content-Type'], 'application/problem+json')
+        self.assertEqual(response.content, '{"title": "Internal Server Error"}')

--- a/palaverapi/tests/test_views.py
+++ b/palaverapi/tests/test_views.py
@@ -49,10 +49,12 @@ class ViewTests(unittest.TestCase):
     def test_push_401_missing_token(self):
         response = self.client.post('/1/push', {})
         self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.headers['Content-Type'], 'application/problem+json')
 
     def test_push_401_invalid_token(self):
         response = self.client.post('/1/push', {}, { 'AUTHORIZATION': 'Bearer' })
         self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.headers['Content-Type'], 'application/problem+json')
 
     def test_push(self):
         enqueued = []
@@ -110,6 +112,7 @@ class DeviceDetailViewTests(unittest.TestCase):
         response = self.client.http('DELETE', '/device', {}, headers)
 
         self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.headers['Content-Type'], 'application/problem+json')
 
 
 class AuthorisationListViewTests(unittest.TestCase):


### PR DESCRIPTION
Following application/problem+json to break consistent error messages to the returned errors: https://tools.ietf.org/html/rfc7807.

This is a first step, we can provide additional details in future too. Have a local changeset to adapter the API client to clean up error handling.